### PR TITLE
Action refactor

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'dev.architectury.loom' version '1.6-SNAPSHOT' apply false
     id 'architectury-plugin' version '3.4-SNAPSHOT'
     id 'com.github.johnrengelman.shadow' version '8.1.1' apply false
-    id 'io.freefair.lombok' version '8.4'
+    id 'io.freefair.lombok' version '8.13.1'
 }
 
 architectury {

--- a/common/src/main/java/net/arna/jcraft/common/attack/actions/CMoonInversionAction.java
+++ b/common/src/main/java/net/arna/jcraft/common/attack/actions/CMoonInversionAction.java
@@ -30,16 +30,17 @@ public class CMoonInversionAction extends MoveAction<CMoonInversionAction, CMoon
         return Type.INSTANCE;
     }
 
-    public static class Type implements MoveActionType<CMoonInversionAction> {
+    public static class Type extends MoveActionType<CMoonInversionAction> {
         public static final Type INSTANCE = new Type();
 
         @Override
         public Codec<CMoonInversionAction> getCodec() {
             return RecordCodecBuilder.create(instance -> instance.group(
+                    runMoment(),
                     Codec.INT.fieldOf("time").forGetter(CMoonInversionAction::getTime),
                     Codec.FLOAT.fieldOf("damage").forGetter(CMoonInversionAction::getDamage),
                     Codec.BOOL.fieldOf("slow").forGetter(CMoonInversionAction::isSlow)
-            ).apply(instance, CMoonInversionAction::addInversion));
+            ).apply(instance, apply(CMoonInversionAction::addInversion)));
         }
     }
 }

--- a/common/src/main/java/net/arna/jcraft/common/attack/actions/CancelSpecMoveAction.java
+++ b/common/src/main/java/net/arna/jcraft/common/attack/actions/CancelSpecMoveAction.java
@@ -1,7 +1,7 @@
 package net.arna.jcraft.common.attack.actions;
 
 import com.mojang.serialization.Codec;
-import lombok.AccessLevel;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import net.arna.jcraft.common.attack.core.MoveAction;
@@ -14,11 +14,8 @@ import net.minecraft.world.entity.LivingEntity;
 
 import java.util.Set;
 
-@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+@RequiredArgsConstructor(staticName = "cancelSpecMove")
 public class CancelSpecMoveAction extends MoveAction<CancelSpecMoveAction, StandEntity<?, ?>> {
-    public static CancelSpecMoveAction cancelSpecMove() {
-        return new CancelSpecMoveAction();
-    }
 
     @Override
     public void perform(StandEntity<?, ?> attacker, LivingEntity user, MoveContext ctx, Set<LivingEntity> targets) {
@@ -33,12 +30,14 @@ public class CancelSpecMoveAction extends MoveAction<CancelSpecMoveAction, Stand
         return Type.INSTANCE;
     }
 
-    public static class Type implements MoveActionType<CancelSpecMoveAction> {
+    public static class Type extends MoveActionType<CancelSpecMoveAction> {
         public static final Type INSTANCE = new Type();
 
         @Override
         public Codec<CancelSpecMoveAction> getCodec() {
-            return Codec.unit(new CancelSpecMoveAction());
+            return RecordCodecBuilder.create(instance -> instance.group(
+                    runMoment()
+            ).apply(instance, apply(CancelSpecMoveAction::new)));
         }
     }
 }

--- a/common/src/main/java/net/arna/jcraft/common/attack/actions/EffectAction.java
+++ b/common/src/main/java/net/arna/jcraft/common/attack/actions/EffectAction.java
@@ -108,15 +108,16 @@ public class EffectAction extends MoveAction<EffectAction, IAttacker<?, ?>> {
         }
     }
 
-    public static class Type implements MoveActionType<EffectAction> {
+    public static class Type extends MoveActionType<EffectAction> {
         public static final Type INSTANCE = new Type();
 
         @Override
         public Codec<EffectAction> getCodec() {
             return RecordCodecBuilder.create(instance -> instance.group(
+                    runMoment(),
                     JCodecUtils.MOB_EFFECT_INSTANCE_CODEC.listOf().fieldOf("effects").forGetter(a ->
                             a.getEffects().stream().map(Supplier::get).toList())
-            ).apply(instance, effects -> inflict(effects.toArray(MobEffectInstance[]::new))));
+            ).apply(instance, apply(effects -> inflict(effects.toArray(MobEffectInstance[]::new)))));
         }
     }
 }

--- a/common/src/main/java/net/arna/jcraft/common/attack/actions/LungeAction.java
+++ b/common/src/main/java/net/arna/jcraft/common/attack/actions/LungeAction.java
@@ -64,7 +64,8 @@ public class LungeAction extends MoveAction<LungeAction, IAttacker<?, ?>> {
                     Codec.FLOAT.fieldOf("vertical_factor").forGetter(LungeAction::getVerticalFactor),
                     Codec.BOOL.optionalFieldOf("on_ground", false).forGetter(LungeAction::requireOnGround),
                     Codec.BOOL.optionalFieldOf("not_free", false).forGetter(LungeAction::requireNotFree)
-            ).apply(instance, apply(LungeAction::new)));
+            ).apply(instance, apply((factor, verticalFactor, onGround, notFree) ->
+                    new LungeAction(factor, verticalFactor))));
         }
     }
 }

--- a/common/src/main/java/net/arna/jcraft/common/attack/actions/LungeAction.java
+++ b/common/src/main/java/net/arna/jcraft/common/attack/actions/LungeAction.java
@@ -53,17 +53,18 @@ public class LungeAction extends MoveAction<LungeAction, IAttacker<?, ?>> {
         return Type.INSTANCE;
     }
 
-    public static class Type implements MoveActionType<LungeAction> {
+    public static class Type extends MoveActionType<LungeAction> {
         public static final Type INSTANCE = new Type();
 
         @Override
         public Codec<LungeAction> getCodec() {
             return RecordCodecBuilder.create(instance -> instance.group(
+                    runMoment(),
                     Codec.FLOAT.fieldOf("factor").forGetter(LungeAction::getFactor),
                     Codec.FLOAT.fieldOf("vertical_factor").forGetter(LungeAction::getVerticalFactor),
                     Codec.BOOL.optionalFieldOf("on_ground", false).forGetter(LungeAction::requireOnGround),
                     Codec.BOOL.optionalFieldOf("not_free", false).forGetter(LungeAction::requireNotFree)
-            ).apply(instance, LungeAction::new));
+            ).apply(instance, apply(LungeAction::new)));
         }
     }
 }

--- a/common/src/main/java/net/arna/jcraft/common/attack/actions/MetallicaAddIronAction.java
+++ b/common/src/main/java/net/arna/jcraft/common/attack/actions/MetallicaAddIronAction.java
@@ -2,7 +2,6 @@ package net.arna.jcraft.common.attack.actions;
 
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
-import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
@@ -15,13 +14,9 @@ import net.minecraft.world.entity.LivingEntity;
 import java.util.Set;
 
 @Getter
-@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+@RequiredArgsConstructor(staticName = "addIron")
 public class MetallicaAddIronAction extends MoveAction<MetallicaAddIronAction, MetallicaEntity> {
     private final float iron;
-
-    public static MetallicaAddIronAction addIron(float iron) {
-        return new MetallicaAddIronAction(iron);
-    }
 
     @Override
     public void perform(MetallicaEntity attacker, LivingEntity user, MoveContext ctx, Set<LivingEntity> targets) {
@@ -33,14 +28,15 @@ public class MetallicaAddIronAction extends MoveAction<MetallicaAddIronAction, M
         return Type.INSTANCE;
     }
 
-    public static class Type implements MoveActionType<MetallicaAddIronAction> {
+    public static class Type extends MoveActionType<MetallicaAddIronAction> {
         public static final Type INSTANCE = new Type();
 
         @Override
         public Codec<MetallicaAddIronAction> getCodec() {
             return RecordCodecBuilder.create(instance -> instance.group(
-                Codec.FLOAT.fieldOf("iron").forGetter(MetallicaAddIronAction::getIron)
-            ).apply(instance, MetallicaAddIronAction::new));
+                    runMoment(),
+                    Codec.FLOAT.fieldOf("iron").forGetter(MetallicaAddIronAction::getIron)
+            ).apply(instance, apply(MetallicaAddIronAction::addIron)));
         }
     }
 }

--- a/common/src/main/java/net/arna/jcraft/common/attack/actions/PlaySoundAction.java
+++ b/common/src/main/java/net/arna/jcraft/common/attack/actions/PlaySoundAction.java
@@ -100,19 +100,20 @@ public class PlaySoundAction extends MoveAction<PlaySoundAction, IAttacker<?, ?>
         return Type.INSTANCE;
     }
 
-    public static class Type implements MoveActionType<PlaySoundAction> {
+    public static class Type extends MoveActionType<PlaySoundAction> {
         public static final Type INSTANCE = new Type();
 
         @Override
         public Codec<PlaySoundAction> getCodec() {
             return RecordCodecBuilder.create(instance -> instance.group(
+                    runMoment(),
                     JCodecUtils.SOUND_EVENT_SUPPLIER_CODEC.fieldOf("sound").forGetter(PlaySoundAction::getSound),
                     Codec.FLOAT.optionalFieldOf("min_vol", 1f).forGetter(PlaySoundAction::getMinVol),
                     Codec.FLOAT.optionalFieldOf("max_vol", 1f).forGetter(PlaySoundAction::getMaxVol),
                     Codec.FLOAT.optionalFieldOf("min_pitch", 1f).forGetter(PlaySoundAction::getMinPitch),
                     Codec.FLOAT.optionalFieldOf("max_pitch", 1f).forGetter(PlaySoundAction::getMaxPitch),
                     Codec.BOOL.optionalFieldOf("on_impact", false).forGetter(PlaySoundAction::isOnImpact)
-            ).apply(instance, PlaySoundAction::new));
+            ).apply(instance, apply(PlaySoundAction::new)));
         }
     }
 }

--- a/common/src/main/java/net/arna/jcraft/common/attack/actions/PlaySoundAction.java
+++ b/common/src/main/java/net/arna/jcraft/common/attack/actions/PlaySoundAction.java
@@ -3,12 +3,11 @@ package net.arna.jcraft.common.attack.actions;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import dev.architectury.registry.registries.RegistrySupplier;
-import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
 import net.arna.jcraft.common.attack.core.IAttacker;
 import net.arna.jcraft.common.attack.core.MoveAction;
+import net.arna.jcraft.common.attack.core.RunMoment;
 import net.arna.jcraft.common.attack.core.ctx.MoveContext;
 import net.arna.jcraft.common.attack.core.data.MoveActionType;
 import net.arna.jcraft.common.util.JCodecUtils;
@@ -20,11 +19,21 @@ import java.util.Set;
 import java.util.function.Supplier;
 
 @Getter
-@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public class PlaySoundAction extends MoveAction<PlaySoundAction, IAttacker<?, ?>> {
     private final Supplier<SoundEvent> sound;
     private final float minVol, maxVol, minPitch, maxPitch;
-    private final boolean onImpact;
+
+    private PlaySoundAction(final Supplier<SoundEvent> sound, final float minVol, final float maxVol,
+                            final float minPitch, final float maxPitch, final boolean onImpact) {
+        this.sound = sound;
+        this.minVol = minVol;
+        this.maxVol = maxVol;
+        this.minPitch = minPitch;
+        this.maxPitch = maxPitch;
+
+        if (onImpact)
+            setRunMoment(RunMoment.ON_HIT);
+    }
 
     public static PlaySoundAction playSound(SoundEvent sound) {
         return playSound(sound, 1.0F, 1.0F);
@@ -88,9 +97,6 @@ public class PlaySoundAction extends MoveAction<PlaySoundAction, IAttacker<?, ?>
 
     @Override
     public void perform(IAttacker<?, ?> attacker, LivingEntity user, MoveContext ctx, Set<LivingEntity> targets) {
-        if (onImpact && targets.isEmpty()) {
-            return;
-        }
         attacker.playAttackerSound(sound.get(), randomize(attacker.getBaseEntity().getRandom(), minVol, maxVol),
                 randomize(attacker.getBaseEntity().getRandom(), minPitch, maxPitch));
     }
@@ -111,9 +117,9 @@ public class PlaySoundAction extends MoveAction<PlaySoundAction, IAttacker<?, ?>
                     Codec.FLOAT.optionalFieldOf("min_vol", 1f).forGetter(PlaySoundAction::getMinVol),
                     Codec.FLOAT.optionalFieldOf("max_vol", 1f).forGetter(PlaySoundAction::getMaxVol),
                     Codec.FLOAT.optionalFieldOf("min_pitch", 1f).forGetter(PlaySoundAction::getMinPitch),
-                    Codec.FLOAT.optionalFieldOf("max_pitch", 1f).forGetter(PlaySoundAction::getMaxPitch),
-                    Codec.BOOL.optionalFieldOf("on_impact", false).forGetter(PlaySoundAction::isOnImpact)
-            ).apply(instance, apply(PlaySoundAction::new)));
+                    Codec.FLOAT.optionalFieldOf("max_pitch", 1f).forGetter(PlaySoundAction::getMaxPitch)
+            ).apply(instance, apply((sound, minVol, maxVol, minPitch, maxPitch) ->
+                    new PlaySoundAction(sound, minVol, maxVol, minPitch, maxPitch, false))));
         }
     }
 }

--- a/common/src/main/java/net/arna/jcraft/common/attack/actions/RunCommandAction.java
+++ b/common/src/main/java/net/arna/jcraft/common/attack/actions/RunCommandAction.java
@@ -1,0 +1,65 @@
+package net.arna.jcraft.common.attack.actions;
+
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import net.arna.jcraft.JCraft;
+import net.arna.jcraft.common.attack.core.IAttacker;
+import net.arna.jcraft.common.attack.core.MoveAction;
+import net.arna.jcraft.common.attack.core.ctx.MoveContext;
+import net.arna.jcraft.common.attack.core.data.MoveActionType;
+import net.minecraft.ChatFormatting;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.network.chat.Component;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.world.entity.LivingEntity;
+
+import java.util.Set;
+
+@Getter
+@RequiredArgsConstructor(staticName = "run")
+public class RunCommandAction extends MoveAction<RunCommandAction, IAttacker<?, ?>> {
+    private final String command;
+
+    @Override
+    public void perform(final IAttacker<?, ?> attacker, final LivingEntity user, final MoveContext ctx, final Set<LivingEntity> targets) {
+        MinecraftServer server = attacker.getEntityWorld().getServer();
+        if (server == null) {
+            return;
+        }
+
+        CommandSourceStack source = server.createCommandSourceStack();
+        if (user != null) {
+            source = source.withEntity(user).withPosition(user.position());
+        }
+        try {
+            server.getCommands().getDispatcher().execute(command, source);
+        } catch (CommandSyntaxException e) {
+            if (user != null) {
+                user.sendSystemMessage(Component.literal("An unknown error occurred while executing a 'Run Command' action. " +
+                        "Check the console for details.").withStyle(ChatFormatting.RED));
+            }
+
+            JCraft.LOGGER.error("An error occurred while executing command '{}' for a RunCommand action.", command, e);
+        }
+    }
+
+    @Override
+    public @NonNull MoveActionType<RunCommandAction> getType() {
+        return Type.INSTANCE;
+    }
+
+    public static class Type implements MoveActionType<RunCommandAction> {
+        public static final Type INSTANCE = new Type();
+
+        @Override
+        public Codec<RunCommandAction> getCodec() {
+            return RecordCodecBuilder.create(instance -> instance.group(
+                    Codec.STRING.fieldOf("command").forGetter(RunCommandAction::getCommand)
+            ).apply(instance, RunCommandAction::run));
+        }
+    }
+}

--- a/common/src/main/java/net/arna/jcraft/common/attack/actions/RunCommandAction.java
+++ b/common/src/main/java/net/arna/jcraft/common/attack/actions/RunCommandAction.java
@@ -52,14 +52,15 @@ public class RunCommandAction extends MoveAction<RunCommandAction, IAttacker<?, 
         return Type.INSTANCE;
     }
 
-    public static class Type implements MoveActionType<RunCommandAction> {
+    public static class Type extends MoveActionType<RunCommandAction> {
         public static final Type INSTANCE = new Type();
 
         @Override
         public Codec<RunCommandAction> getCodec() {
             return RecordCodecBuilder.create(instance -> instance.group(
+                    runMoment(),
                     Codec.STRING.fieldOf("command").forGetter(RunCommandAction::getCommand)
-            ).apply(instance, RunCommandAction::run));
+            ).apply(instance, apply(RunCommandAction::run)));
         }
     }
 }

--- a/common/src/main/java/net/arna/jcraft/common/attack/actions/ScoreboardAction.java
+++ b/common/src/main/java/net/arna/jcraft/common/attack/actions/ScoreboardAction.java
@@ -1,0 +1,74 @@
+package net.arna.jcraft.common.attack.actions;
+
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import net.arna.jcraft.common.attack.core.IAttacker;
+import net.arna.jcraft.common.attack.core.MoveAction;
+import net.arna.jcraft.common.attack.core.ctx.MoveContext;
+import net.arna.jcraft.common.attack.core.data.MoveActionType;
+import net.arna.jcraft.common.util.JCodecUtils;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.ServerScoreboard;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.scores.Objective;
+import net.minecraft.world.scores.Score;
+
+import java.util.Set;
+
+@Getter
+@RequiredArgsConstructor(staticName = "of")
+public class ScoreboardAction extends MoveAction<ScoreboardAction, IAttacker<?, ?>> {
+    private final String objective;
+    private final ScoreboardActionType actionType;
+    private final int value;
+
+    @Override
+    public void perform(final IAttacker<?, ?> attacker, final LivingEntity user, final MoveContext ctx, final Set<LivingEntity> targets) {
+        MinecraftServer server = attacker.getEntityWorld().getServer();
+        if (server == null) {
+            return;
+        }
+
+        ServerScoreboard scoreboard = server.getScoreboard();
+        Objective objective = scoreboard.getOrCreateObjective(this.objective);
+        Score score = scoreboard.getOrCreatePlayerScore(user.getScoreboardName(), objective);
+
+        switch (this.actionType) {
+            case ADD -> score.setScore(score.getScore() + this.value);
+            case MULTIPLY -> score.setScore(score.getScore() * this.value);
+            case SET -> score.setScore(this.value);
+        }
+    }
+
+    @Override
+    public @NonNull MoveActionType<ScoreboardAction> getType() {
+        return Type.INSTANCE;
+    }
+
+    public static class Type implements MoveActionType<ScoreboardAction> {
+        public static final Type INSTANCE = new Type();
+        @Getter
+        private final Codec<ScoreboardAction> codec = RecordCodecBuilder.create(instance ->
+                instance.group(
+                        Codec.STRING.fieldOf("objective").forGetter(ScoreboardAction::getObjective),
+                        JCodecUtils.createEnumCodec(ScoreboardActionType.class).fieldOf("actionType").forGetter(ScoreboardAction::getActionType),
+                        Codec.INT.fieldOf("value").forGetter(ScoreboardAction::getValue)
+                ).apply(instance, ScoreboardAction::of));
+    }
+
+    @Getter
+    public enum ScoreboardActionType {
+        ADD("add"),
+        MULTIPLY("multiply"),
+        SET("set");
+
+        private final String name;
+
+        ScoreboardActionType(String name) {
+            this.name = name;
+        }
+    }
+}

--- a/common/src/main/java/net/arna/jcraft/common/attack/actions/ScoreboardAction.java
+++ b/common/src/main/java/net/arna/jcraft/common/attack/actions/ScoreboardAction.java
@@ -48,15 +48,16 @@ public class ScoreboardAction extends MoveAction<ScoreboardAction, IAttacker<?, 
         return Type.INSTANCE;
     }
 
-    public static class Type implements MoveActionType<ScoreboardAction> {
+    public static class Type extends MoveActionType<ScoreboardAction> {
         public static final Type INSTANCE = new Type();
         @Getter
         private final Codec<ScoreboardAction> codec = RecordCodecBuilder.create(instance ->
                 instance.group(
+                        runMoment(),
                         Codec.STRING.fieldOf("objective").forGetter(ScoreboardAction::getObjective),
                         JCodecUtils.createEnumCodec(ScoreboardActionType.class).fieldOf("actionType").forGetter(ScoreboardAction::getActionType),
                         Codec.INT.fieldOf("value").forGetter(ScoreboardAction::getValue)
-                ).apply(instance, ScoreboardAction::of));
+                ).apply(instance, apply(ScoreboardAction::of)));
     }
 
     @Getter

--- a/common/src/main/java/net/arna/jcraft/common/attack/actions/UserAnimationAction.java
+++ b/common/src/main/java/net/arna/jcraft/common/attack/actions/UserAnimationAction.java
@@ -34,15 +34,16 @@ public class UserAnimationAction extends MoveAction<UserAnimationAction, IAttack
         return Type.INSTANCE;
     }
 
-    public static class Type implements MoveActionType<UserAnimationAction> {
+    public static class Type extends MoveActionType<UserAnimationAction> {
         public static final Type INSTANCE = new Type();
 
         @Override
         public Codec<UserAnimationAction> getCodec() {
             return RecordCodecBuilder.create(instance -> instance.group(
+                    runMoment(),
                     Codec.STRING.fieldOf("animation").forGetter(UserAnimationAction::getAnimation),
                     Codec.BOOL.optionalFieldOf("force", false).forGetter(UserAnimationAction::isForce)
-            ).apply(instance, UserAnimationAction::new));
+            ).apply(instance, apply((anim, force) -> new UserAnimationAction(anim, force))));
         }
     }
 }

--- a/common/src/main/java/net/arna/jcraft/common/attack/core/BaseMoveExtras.java
+++ b/common/src/main/java/net/arna/jcraft/common/attack/core/BaseMoveExtras.java
@@ -25,7 +25,6 @@ public class BaseMoveExtras {
             ExtraCodecs.COMPONENT.optionalFieldOf("description", Component.empty()).forGetter(BaseMoveExtras::getDescription),
             MoveSetLoader.MOVE_CONDITION_CODEC.get().listOf().optionalFieldOf("conditions", new ArrayList<>()).forGetter(BaseMoveExtras::getConditions),
             MoveSetLoader.MOVE_ACTION_CODEC.get().listOf().optionalFieldOf("actions", new ArrayList<>()).forGetter(BaseMoveExtras::getActions),
-            MoveSetLoader.MOVE_ACTION_CODEC.get().listOf().optionalFieldOf("init_actions", new ArrayList<>()).forGetter(BaseMoveExtras::getInitActions),
             ExtraCodecs.NON_NEGATIVE_INT.optionalFieldOf("armor", 0).forGetter(BaseMoveExtras::getArmor),
             MobilityType.CODEC.optionalFieldOf("mobility_type").forGetter(BaseMoveExtras::getMobilityType),
             Codec.BOOL.optionalFieldOf("is_holdable").forGetter(BaseMoveExtras::getIsHoldable),
@@ -53,7 +52,7 @@ public class BaseMoveExtras {
     private OptionalInt followupFrame = OptionalInt.empty();
 
     private BaseMoveExtras(final Component name, final Component description, final List<MoveCondition<?, ?>> conditions,
-                           final List<MoveAction<?, ?>> actions, final List<MoveAction<?, ?>> initActions,
+                           final List<MoveAction<?, ?>> actions,
                            final int armor, Optional<MobilityType> mobilityType, final Optional<Boolean> isHoldable, final boolean ranged,
                            final boolean mayHitUser, final Optional<IntObjectPair<AbstractMove<?, ?>>> finisher,
                            final OptionalInt followupFrame) {
@@ -61,7 +60,6 @@ public class BaseMoveExtras {
         this.description = description;
         this.conditions.addAll(conditions);
         this.actions.addAll(actions);
-        this.initActions.addAll(initActions);
         this.armor = armor;
         this.mobilityType = mobilityType;
         this.isHoldable = isHoldable;
@@ -74,7 +72,7 @@ public class BaseMoveExtras {
     @SuppressWarnings({"unchecked", "RedundantCast", "rawtypes"})
     public static <A extends IAttacker<? extends A, ?>> BaseMoveExtras fromMove(final AbstractMove<?, A> move) {
         return new BaseMoveExtras(move.getName(), move.getDescription(), (List<MoveCondition<?, ?>>) (List) move.getConditions(),
-                (List<MoveAction<?, ?>>) (List) move.getActions(), (List<MoveAction<?, ?>>) (List) move.getInitActions(),
+                (List<MoveAction<?, ?>>) (List) move.getActions(),
                 move.getArmor(), Optional.ofNullable(move.getMobilityType()), Optional.ofNullable(move.getIsHoldable()),
                 move.isRanged(), move.isMayHitUser(), Optional.ofNullable((IntObjectPair<AbstractMove<?, ?>>) (IntObjectPair) move.getFinisher()),
                 move.getFollowupFrame());

--- a/common/src/main/java/net/arna/jcraft/common/attack/core/MoveAction.java
+++ b/common/src/main/java/net/arna/jcraft/common/attack/core/MoveAction.java
@@ -1,13 +1,19 @@
 package net.arna.jcraft.common.attack.core;
 
+import lombok.Getter;
 import lombok.NonNull;
+import lombok.Setter;
 import net.arna.jcraft.common.attack.core.ctx.MoveContext;
 import net.arna.jcraft.common.attack.core.data.MoveActionType;
 import net.minecraft.world.entity.LivingEntity;
 
 import java.util.Set;
 
+@Getter
+@Setter
 public abstract class MoveAction<T extends MoveAction<? extends T, A>, A extends IAttacker<? extends A, ?>> {
+    private RunMoment runMoment = RunMoment.ON_STRIKE;
+
     protected MoveAction() {}
 
     public abstract void perform(final A attacker, final LivingEntity user, final MoveContext ctx, final Set<LivingEntity> targets);

--- a/common/src/main/java/net/arna/jcraft/common/attack/core/RunMoment.java
+++ b/common/src/main/java/net/arna/jcraft/common/attack/core/RunMoment.java
@@ -18,6 +18,7 @@ import java.util.function.Supplier;
 
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public abstract class RunMoment {
+    private static final BiMap<String, RunMomentType<?>> BY_NAME = HashBiMap.create();
     public static RunMoment NEVER, AT_INIT, ON_STRIKE, ON_HIT, AT_END, EVERY_TICK;
 
     static {
@@ -30,8 +31,6 @@ public abstract class RunMoment {
         AT_END = create("on_end", RunMomentType.unit(() -> AT_END));
         EVERY_TICK = create("every_tick", RunMomentType.unit(() -> EVERY_TICK));
     }
-
-    private static final BiMap<String, RunMomentType<?>> BY_NAME = HashBiMap.create();
 
     public static MapCodec<RunMoment> CODEC = JCodecUtils.codecFromMap(Codec.STRING, BY_NAME)
             .dispatchMap("run", RunMoment::getType, RunMomentType::getCodec);

--- a/common/src/main/java/net/arna/jcraft/common/attack/core/RunMoment.java
+++ b/common/src/main/java/net/arna/jcraft/common/attack/core/RunMoment.java
@@ -89,7 +89,7 @@ public abstract class RunMoment {
         @Override
         public boolean shouldRun(final AbstractMove<?, ?> move, final IAttacker<?, ?> attacker, final LivingEntity user,
                                  final int tick, final @Nullable Set<LivingEntity> targets) {
-            return tick == this.tick;
+            return tick < 0 ? attacker.getMoveStun() == -tick - 1 : tick == this.tick;
         }
     }
 

--- a/common/src/main/java/net/arna/jcraft/common/attack/core/RunMoment.java
+++ b/common/src/main/java/net/arna/jcraft/common/attack/core/RunMoment.java
@@ -1,0 +1,104 @@
+package net.arna.jcraft.common.attack.core;
+
+import com.google.common.collect.BiMap;
+import com.google.common.collect.HashBiMap;
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.MapCodec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import net.arna.jcraft.common.attack.moves.base.AbstractMove;
+import net.arna.jcraft.common.util.JCodecUtils;
+import net.minecraft.world.entity.LivingEntity;
+
+import javax.annotation.Nullable;
+import java.util.Set;
+import java.util.function.Supplier;
+
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public abstract class RunMoment {
+    public static RunMoment NEVER, AT_INIT, ON_STRIKE, ON_HIT, AT_END, EVERY_TICK;
+
+    static {
+        NEVER = create("never", RunMomentType.unit(() -> NEVER),
+                (move, attacker, user, tick, targets) -> false);
+        AT_INIT = create("at_init", RunMomentType.unit(() -> AT_INIT), // Special case
+                (move, attacker, user, tick, targets) -> tick == 0);
+        ON_STRIKE = create("on_strike", RunMomentType.unit(() -> ON_STRIKE),
+                (move, attacker, user, tick, targets) -> tick == move.getWindup() && targets == null);
+        ON_HIT = create("on_hit", RunMomentType.unit(() -> ON_HIT),
+                (move, attacker, user, tick, targets) -> tick == move.getWindup() && targets != null && !targets.isEmpty());
+        AT_END = create("on_end", RunMomentType.unit(() -> AT_END),
+                (move, attacker, user, tick, targets) -> tick == move.getDuration());
+        EVERY_TICK = create("every_tick", RunMomentType.unit(() -> EVERY_TICK),
+                (move, attacker, user, tick, targets) -> true);
+    }
+
+    private static final BiMap<String, RunMomentType<?>> BY_NAME = HashBiMap.create();
+
+    public static MapCodec<RunMoment> CODEC = JCodecUtils.codecFromMap(Codec.STRING, BY_NAME)
+            .dispatchMap("run", RunMoment::getType, RunMomentType::getCodec);
+
+    @Getter
+    private final RunMomentType<?> type;
+
+    private static RunMoment create(String name, RunMomentType<?> type, RunMomentFunc func) {
+        RunMoment runMoment = new RunMoment(type) {
+            @Override
+            public boolean shouldRun(final AbstractMove<?, ?> move, final IAttacker<?, ?> attacker, final LivingEntity user,
+                                     final int tick, final @Nullable Set<LivingEntity> targets) {
+                return func.shouldRun(move, attacker, user, tick, targets);
+            }
+        };
+
+        BY_NAME.put(name, type);
+        return runMoment;
+    }
+
+    public static RunMoment atTick(final int tick) {
+        return new TickRunMoment(tick);
+    }
+
+    public abstract boolean shouldRun(final AbstractMove<?, ?> move, final IAttacker<?, ?> attacker, final LivingEntity user,
+                                      final int tick, final @Nullable Set<LivingEntity> targets);
+
+    public interface RunMomentType<T extends RunMoment> {
+        Codec<T> getCodec();
+
+        static <T extends RunMoment> RunMomentType<T> unit(Supplier<T> runMoment) {
+            return () -> Codec.unit(runMoment);
+        }
+    }
+
+    @FunctionalInterface
+    private interface RunMomentFunc {
+        boolean shouldRun(final AbstractMove<?, ?> move, final IAttacker<?, ?> attacker, final LivingEntity user,
+                          final int tick, final @Nullable Set<LivingEntity> targets);
+    }
+
+    private static class TickRunMoment extends RunMoment {
+        private final int tick;
+
+        public TickRunMoment(final int tick) {
+            super(TickRunMomentType.INSTANCE);
+            this.tick = tick;
+        }
+
+        @Override
+        public boolean shouldRun(final AbstractMove<?, ?> move, final IAttacker<?, ?> attacker, final LivingEntity user,
+                                 final int tick, final @Nullable Set<LivingEntity> targets) {
+            return tick == this.tick;
+        }
+    }
+
+    private static class TickRunMomentType implements RunMomentType<TickRunMoment> {
+        public static final TickRunMomentType INSTANCE = new TickRunMomentType();
+        @Getter
+        private static final Codec<TickRunMoment> codec = RecordCodecBuilder.create(instance ->
+                instance.group(
+                        Codec.INT.fieldOf("tick").forGetter(runMoment -> runMoment.tick)
+                ).apply(instance, TickRunMoment::new)
+        );
+    }
+}

--- a/common/src/main/java/net/arna/jcraft/common/attack/core/RunMoment.java
+++ b/common/src/main/java/net/arna/jcraft/common/attack/core/RunMoment.java
@@ -94,11 +94,15 @@ public abstract class RunMoment {
 
     private static class TickRunMomentType implements RunMomentType<TickRunMoment> {
         public static final TickRunMomentType INSTANCE = new TickRunMomentType();
-        @Getter
         private static final Codec<TickRunMoment> codec = RecordCodecBuilder.create(instance ->
                 instance.group(
                         Codec.INT.fieldOf("tick").forGetter(runMoment -> runMoment.tick)
                 ).apply(instance, TickRunMoment::new)
         );
+
+        @Override
+        public Codec<TickRunMoment> getCodec() {
+            return codec;
+        }
     }
 }

--- a/common/src/main/java/net/arna/jcraft/common/attack/core/RunMoment.java
+++ b/common/src/main/java/net/arna/jcraft/common/attack/core/RunMoment.java
@@ -21,18 +21,14 @@ public abstract class RunMoment {
     public static RunMoment NEVER, AT_INIT, ON_STRIKE, ON_HIT, AT_END, EVERY_TICK;
 
     static {
-        NEVER = create("never", RunMomentType.unit(() -> NEVER),
-                (move, attacker, user, tick, targets) -> false);
-        AT_INIT = create("at_init", RunMomentType.unit(() -> AT_INIT), // Special case
-                (move, attacker, user, tick, targets) -> tick == 0);
-        ON_STRIKE = create("on_strike", RunMomentType.unit(() -> ON_STRIKE),
-                (move, attacker, user, tick, targets) -> tick == move.getWindup() && targets == null);
-        ON_HIT = create("on_hit", RunMomentType.unit(() -> ON_HIT),
-                (move, attacker, user, tick, targets) -> tick == move.getWindup() && targets != null && !targets.isEmpty());
-        AT_END = create("on_end", RunMomentType.unit(() -> AT_END),
-                (move, attacker, user, tick, targets) -> tick == move.getDuration());
-        EVERY_TICK = create("every_tick", RunMomentType.unit(() -> EVERY_TICK),
-                (move, attacker, user, tick, targets) -> true);
+        // All of these have special handling (see usages in AbstractMove).
+        // The shouldRun method is only used for atTick run moments.
+        NEVER = create("never", RunMomentType.unit(() -> NEVER));
+        AT_INIT = create("at_init", RunMomentType.unit(() -> AT_INIT));
+        ON_STRIKE = create("on_strike", RunMomentType.unit(() -> ON_STRIKE));
+        ON_HIT = create("on_hit", RunMomentType.unit(() -> ON_HIT));
+        AT_END = create("on_end", RunMomentType.unit(() -> AT_END));
+        EVERY_TICK = create("every_tick", RunMomentType.unit(() -> EVERY_TICK));
     }
 
     private static final BiMap<String, RunMomentType<?>> BY_NAME = HashBiMap.create();
@@ -42,6 +38,10 @@ public abstract class RunMoment {
 
     @Getter
     private final RunMomentType<?> type;
+
+    private static RunMoment create(String name, RunMomentType<?> type) {
+        return create(name, type, (move, attacker, user, tick, targets) -> false);
+    }
 
     private static RunMoment create(String name, RunMomentType<?> type, RunMomentFunc func) {
         RunMoment runMoment = new RunMoment(type) {

--- a/common/src/main/java/net/arna/jcraft/common/attack/core/RunMoment.java
+++ b/common/src/main/java/net/arna/jcraft/common/attack/core/RunMoment.java
@@ -30,6 +30,8 @@ public abstract class RunMoment {
         ON_HIT = create("on_hit", RunMomentType.unit(() -> ON_HIT));
         AT_END = create("on_end", RunMomentType.unit(() -> AT_END));
         EVERY_TICK = create("every_tick", RunMomentType.unit(() -> EVERY_TICK));
+
+        BY_NAME.put("at_tick", TickRunMomentType.INSTANCE); // Special case for atTick, which is handled differently.
     }
 
     public static MapCodec<RunMoment> CODEC = JCodecUtils.codecFromMap(Codec.STRING, BY_NAME)

--- a/common/src/main/java/net/arna/jcraft/common/attack/core/data/MoveActionType.java
+++ b/common/src/main/java/net/arna/jcraft/common/attack/core/data/MoveActionType.java
@@ -57,6 +57,15 @@ public abstract class MoveActionType<T extends MoveAction<? extends T, ?>> {
         };
     }
 
+    protected <R extends MoveAction<?, ?>, T1, T2, T3, T4, T5> Function6<RunMoment, T1, T2, T3, T4, T5, R>
+    apply(Function5<T1, T2, T3, T4, T5, R> func) {
+        return (runMoment, t1, t2, t3, t4, t5) -> {
+            R r = func.apply(t1, t2, t3, t4, t5);
+            r.setRunMoment(runMoment);
+            return r;
+        };
+    }
+
     protected <R extends MoveAction<?, ?>, T1, T2, T3, T4, T5, T6> Function7<RunMoment, T1, T2, T3, T4, T5, T6, R>
     apply(Function6<T1, T2, T3, T4, T5, T6, R> func) {
         return (runMoment, t1, t2, t3, t4, t5, t6) -> {

--- a/common/src/main/java/net/arna/jcraft/common/attack/core/data/MoveActionType.java
+++ b/common/src/main/java/net/arna/jcraft/common/attack/core/data/MoveActionType.java
@@ -1,8 +1,68 @@
 package net.arna.jcraft.common.attack.core.data;
 
+import com.mojang.datafixers.util.*;
 import com.mojang.serialization.Codec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
 import net.arna.jcraft.common.attack.core.MoveAction;
+import net.arna.jcraft.common.attack.core.RunMoment;
 
-public interface MoveActionType<T extends MoveAction<? extends T, ?>> {
-    Codec<T> getCodec();
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+public abstract class MoveActionType<T extends MoveAction<? extends T, ?>> {
+    public abstract Codec<T> getCodec();
+
+    protected RecordCodecBuilder<T, RunMoment> runMoment() {
+        return RunMoment.CODEC.orElse(RunMoment.ON_STRIKE).forGetter(MoveAction::getRunMoment);
+    }
+
+    protected <R extends MoveAction<?, ?>> Function<RunMoment, R> apply(Supplier<R> supplier) {
+        return runMoment -> {
+            R r = supplier.get();
+            r.setRunMoment(runMoment);
+            return r;
+        };
+    }
+
+    protected <R extends MoveAction<?, ?>, T1> BiFunction<RunMoment, T1, R> apply(Function<T1, R> func) {
+        return (runMoment, t1) -> {
+            R r = func.apply(t1);
+            r.setRunMoment(runMoment);
+            return r;
+        };
+    }
+
+    protected <R extends MoveAction<?, ?>, T1, T2> Function3<RunMoment, T1, T2, R> apply(BiFunction<T1, T2, R> func) {
+        return (runMoment, t1, t2) -> {
+            R r = func.apply(t1, t2);
+            r.setRunMoment(runMoment);
+            return r;
+        };
+    }
+
+    protected <R extends MoveAction<?, ?>, T1, T2, T3> Function4<RunMoment, T1, T2, T3, R> apply(Function3<T1, T2, T3, R> func) {
+        return (runMoment, t1, t2, t3) -> {
+            R r = func.apply(t1, t2, t3);
+            r.setRunMoment(runMoment);
+            return r;
+        };
+    }
+
+    protected <R extends MoveAction<?, ?>, T1, T2, T3, T4> Function5<RunMoment, T1, T2, T3, T4, R> apply(Function4<T1, T2, T3, T4, R> func) {
+        return (runMoment, t1, t2, t3, t4) -> {
+            R r = func.apply(t1, t2, t3, t4);
+            r.setRunMoment(runMoment);
+            return r;
+        };
+    }
+
+    protected <R extends MoveAction<?, ?>, T1, T2, T3, T4, T5, T6> Function7<RunMoment, T1, T2, T3, T4, T5, T6, R>
+    apply(Function6<T1, T2, T3, T4, T5, T6, R> func) {
+        return (runMoment, t1, t2, t3, t4, t5, t6) -> {
+            R r = func.apply(t1, t2, t3, t4, t5, t6);
+            r.setRunMoment(runMoment);
+            return r;
+        };
+    }
 }

--- a/common/src/main/java/net/arna/jcraft/common/attack/core/data/MoveSet.java
+++ b/common/src/main/java/net/arna/jcraft/common/attack/core/data/MoveSet.java
@@ -325,6 +325,10 @@ public class MoveSet<A extends IAttacker<? extends A, S>, S extends Enum<S>> {
         this.moveMap.copyFrom(moveMap);
 
         initialized = true;
+        // Make a new hashset to avoid concurrent modification exceptions.
+        // Will not be necessary anymore once MoveContext has been yeeted at which point,
+        // we can replace the onMoveSetReload implementation in StandEntity and JSpec with
+        // one that just calls moveMap.copyFrom(moveMap).
         gameExecutor.execute(() -> new HashSet<>(listeners).forEach(listener ->
                 listener.onMoveSetReload(this)));
     }

--- a/common/src/main/java/net/arna/jcraft/common/attack/core/data/MoveSet.java
+++ b/common/src/main/java/net/arna/jcraft/common/attack/core/data/MoveSet.java
@@ -325,7 +325,8 @@ public class MoveSet<A extends IAttacker<? extends A, S>, S extends Enum<S>> {
         this.moveMap.copyFrom(moveMap);
 
         initialized = true;
-        gameExecutor.execute(() -> listeners.forEach(listener -> listener.onMoveSetReload(this)));
+        gameExecutor.execute(() -> new HashSet<>(listeners).forEach(listener ->
+                listener.onMoveSetReload(this)));
     }
 
     /**

--- a/common/src/main/java/net/arna/jcraft/common/attack/core/data/MoveSetLoader.java
+++ b/common/src/main/java/net/arna/jcraft/common/attack/core/data/MoveSetLoader.java
@@ -366,6 +366,8 @@ public class MoveSetLoader {
         registrar.accept("lunge", () -> LungeAction.Type.INSTANCE);
         registrar.accept("cmoon_inversion", () -> CMoonInversionAction.Type.INSTANCE);
         registrar.accept("user_animation", () -> UserAnimationAction.Type.INSTANCE);
+        registrar.accept("run_command", () -> RunCommandAction.Type.INSTANCE);
+        registrar.accept("scoreboard", () -> ScoreboardAction.Type.INSTANCE);
     }
 
     public static Map<Enum<?>, Map<String, MoveSet<?, ?>>> getMoveSets() {

--- a/common/src/main/java/net/arna/jcraft/common/attack/moves/base/AbstractMove.java
+++ b/common/src/main/java/net/arna/jcraft/common/attack/moves/base/AbstractMove.java
@@ -46,7 +46,7 @@ public abstract class AbstractMove<T extends AbstractMove<T, A>, A extends IAtta
     @Getter(AccessLevel.PRIVATE) // shouldn't be used directly
     private final IntMoveVariable CHARGE_TIME = new IntMoveVariable();
     private final List<MoveCondition<?, ? super A>> conditions = new ArrayList<>();
-    private final List<MoveAction<?, ? super A>> actions = new ArrayList<>(), initActions = new ArrayList<>();
+    private final List<MoveAction<?, ? super A>> actions = new ArrayList<>();
     /**
      * Be VERY careful when using this.
      * There's NO connection between static moves defined in fields
@@ -321,12 +321,33 @@ public abstract class AbstractMove<T extends AbstractMove<T, A>, A extends IAtta
     }
 
     /**
+     * Adds a new action to this move.
+     * @param action The action to add
+     * @return This move
+     */
+    public T withAction(final MoveAction<?, ? super A> action, RunMoment runMoment) {
+        action.setRunMoment(runMoment);
+        actions.add(action);
+        return getThis();
+    }
+
+    /**
      * Adds multiple actions to this move.
      * @param actions The actions to add
      * @return This move
      */
     public T withActions(final Collection<MoveAction<?, ? super A>> actions) {
         this.actions.addAll(actions);
+        return getThis();
+    }
+
+    /**
+     * Adds multiple actions to this move.
+     * @param actions The actions to add
+     * @return This move
+     */
+    public T withActions(final Collection<MoveAction<?, ? super A>> actions, RunMoment runMoment) {
+        this.actions.addAll(actions.stream().peek(a -> a.setRunMoment(runMoment)).toList());
         return getThis();
     }
 
@@ -344,8 +365,7 @@ public abstract class AbstractMove<T extends AbstractMove<T, A>, A extends IAtta
      */
 
     public T withInitAction(final MoveAction<?, ? super A> action) {
-        initActions.add(action);
-        return getThis();
+        return withAction(action, RunMoment.AT_INIT);
     }
 
     /**
@@ -354,15 +374,13 @@ public abstract class AbstractMove<T extends AbstractMove<T, A>, A extends IAtta
      * @return This move
      */
     public T withInitActions(final Collection<MoveAction<?, ? super A>> actions) {
-        this.initActions.addAll(actions);
-        return getThis();
+        return withActions(actions, RunMoment.AT_INIT);
     }
 
     @ApiStatus.Internal
     @SuppressWarnings({"unchecked", "RedundantCast", "rawtypes"})
     public T withInitActionsRaw(final Collection<MoveAction<?, ?>> actions) {
-        this.initActions.addAll((Collection<? extends MoveAction<?,? super A>>) (Collection) actions);
-        return getThis();
+        return withInitActions((Collection<MoveAction<?,? super A>>) (Collection) actions);
     }
 
     /**
@@ -460,19 +478,6 @@ public abstract class AbstractMove<T extends AbstractMove<T, A>, A extends IAtta
         return getThis();
     }
 
-    // Lombok does not understand these variable names already start with 'is'.
-    public boolean isCrouchingVariant() {
-        return isCrouchingVariant;
-    }
-
-    public boolean isAerialVariant() {
-        return isAerialVariant;
-    }
-
-    public boolean isFollowup() {
-        return isFollowup;
-    }
-
     /**
      * Called when this move is registered to a {@link net.arna.jcraft.common.attack.core.MoveMap MoveMap}.
      * Not supposed to be called anywhere else.
@@ -556,7 +561,11 @@ public abstract class AbstractMove<T extends AbstractMove<T, A>, A extends IAtta
     public void onInitiate(final A attacker) {
         LivingEntity user = attacker.getUser();
         Set<LivingEntity> targets = Set.of(); // Obviously none yet
-        initActions.forEach(a -> a.perform(attacker, user, attacker.getMoveContext(), targets));
+        for (final MoveAction<?, ? super A> action : actions) {
+            if (action.getRunMoment() == RunMoment.AT_INIT) {
+                action.perform(attacker, user, attacker.getMoveContext(), targets);
+            }
+        }
     }
 
     /**
@@ -592,6 +601,15 @@ public abstract class AbstractMove<T extends AbstractMove<T, A>, A extends IAtta
      * @param attacker The attacker to tick for.
      */
     public void activeTick(final A attacker, final int moveStun) {
+        Set<LivingEntity> targets = Set.of();
+        for (final MoveAction<?, ? super A> action : actions) {
+            if (action.getRunMoment() == RunMoment.EVERY_TICK ||
+                    (action.getRunMoment() == RunMoment.AT_END && moveStun == 0) ||
+                    action.getRunMoment().shouldRun(getThis(), attacker, attacker.getUser(), getDuration() - moveStun, targets)) {
+                action.perform(attacker, attacker.getUserOrThrow(), attacker.getMoveContext(), targets);
+            }
+        }
+
         if (finisher != null && canFinish(attacker) && finisher.leftInt() <= getDuration() - moveStun) {
             attacker.setCurrentMove(finisher.right());
         }
@@ -627,7 +645,11 @@ public abstract class AbstractMove<T extends AbstractMove<T, A>, A extends IAtta
      * @param attacker The attacker that will be performing this move.
      */
     public final void doPerform(final A attacker) {
-        // TODO strike actions
+        for (final MoveAction<?, ? super A> action : actions) {
+            if (action.getRunMoment() == RunMoment.ON_STRIKE) {
+                action.perform(attacker, attacker.getUserOrThrow(), attacker.getMoveContext(), Set.of());
+            }
+        }
 
         LivingEntity user = attacker.getUserOrThrow();
         MoveContext ctx = attacker.getMoveContext();
@@ -636,7 +658,13 @@ public abstract class AbstractMove<T extends AbstractMove<T, A>, A extends IAtta
         actions.forEach(a -> a.perform(attacker, user, ctx, targets));
         attacker.onPerform(this, targets);
 
-        // TODO hit actions (if targets is not empty)
+        if (targets.isEmpty()) return;
+
+        for (final MoveAction<?, ? super A> action : actions) {
+            if (action.getRunMoment() == RunMoment.ON_HIT) {
+                action.perform(attacker, attacker.getUserOrThrow(), attacker.getMoveContext(), Set.of());
+            }
+        }
     }
 
     /**
@@ -838,7 +866,6 @@ public abstract class AbstractMove<T extends AbstractMove<T, A>, A extends IAtta
         cast.aerialVariant = aerialVariant == null ? null : aerialVariant.copy();
         cast.conditions.addAll(conditions);
         cast.actions.addAll(actions);
-        cast.initActions.addAll(initActions);
         cast.followupFrame = followupFrame;
         cast.ranged = ranged;
         cast.isCrouchingVariant = isCrouchingVariant;

--- a/common/src/main/java/net/arna/jcraft/common/attack/moves/base/AbstractMove.java
+++ b/common/src/main/java/net/arna/jcraft/common/attack/moves/base/AbstractMove.java
@@ -627,12 +627,16 @@ public abstract class AbstractMove<T extends AbstractMove<T, A>, A extends IAtta
      * @param attacker The attacker that will be performing this move.
      */
     public final void doPerform(final A attacker) {
+        // TODO strike actions
+
         LivingEntity user = attacker.getUserOrThrow();
         MoveContext ctx = attacker.getMoveContext();
 
         Set<LivingEntity> targets = perform(attacker, user, ctx);
         actions.forEach(a -> a.perform(attacker, user, ctx, targets));
         attacker.onPerform(this, targets);
+
+        // TODO hit actions (if targets is not empty)
     }
 
     /**

--- a/common/src/main/java/net/arna/jcraft/common/attack/moves/base/AbstractMove.java
+++ b/common/src/main/java/net/arna/jcraft/common/attack/moves/base/AbstractMove.java
@@ -662,26 +662,18 @@ public abstract class AbstractMove<T extends AbstractMove<T, A>, A extends IAtta
      * @param attacker The attacker that will be performing this move.
      */
     public final void doPerform(final A attacker) {
-        for (final MoveAction<?, ? super A> action : actions) {
-            if (action.getRunMoment() == RunMoment.ON_STRIKE) {
-                action.perform(attacker, attacker.getUserOrThrow(), attacker.getMoveContext(), Set.of());
-            }
-        }
-
         LivingEntity user = attacker.getUserOrThrow();
         MoveContext ctx = attacker.getMoveContext();
 
         Set<LivingEntity> targets = perform(attacker, user, ctx);
-        actions.forEach(a -> a.perform(attacker, user, ctx, targets));
-        attacker.onPerform(this, targets);
-
-        if (targets.isEmpty()) return;
+        boolean hit = !targets.isEmpty();
 
         for (final MoveAction<?, ? super A> action : actions) {
-            if (action.getRunMoment() == RunMoment.ON_HIT) {
+            if (action.getRunMoment() == RunMoment.ON_STRIKE || hit && action.getRunMoment() == RunMoment.ON_HIT) {
                 action.perform(attacker, attacker.getUserOrThrow(), attacker.getMoveContext(), Set.of());
             }
         }
+        attacker.onPerform(this, targets);
     }
 
     /**

--- a/common/src/main/java/net/arna/jcraft/common/attack/moves/base/AbstractMove.java
+++ b/common/src/main/java/net/arna/jcraft/common/attack/moves/base/AbstractMove.java
@@ -53,7 +53,6 @@ public abstract class AbstractMove<T extends AbstractMove<T, A>, A extends IAtta
      * and moves that are actually executed (because of (de)serialization).
      * This is for internal use only.
      */
-    @Getter
     private T originalMove = getThis();
     private MoveClass moveClass;
     private int cooldown, windup;
@@ -62,7 +61,6 @@ public abstract class AbstractMove<T extends AbstractMove<T, A>, A extends IAtta
     /**
      * This move's assigned animation
      */
-    @Getter
     private Enum<?> animation;
     @NonNull
     private Component name = Component.empty(), description = Component.empty();
@@ -476,6 +474,25 @@ public abstract class AbstractMove<T extends AbstractMove<T, A>, A extends IAtta
     public T withFollowupFrame(final OptionalInt frame) {
         followupFrame = frame;
         return getThis();
+    }
+
+    // Lombok does not understand these variable names already start with 'is',
+    // even though IntelliJ thinks it does.
+    // Also, for some reason, suppressing the warning gives a warning about the suppression being redundant,
+    // even though it is not.
+    @SuppressWarnings({"LombokGetterMayBeUsed", "RedundantSuppression"})
+    public boolean isCrouchingVariant() {
+        return isCrouchingVariant;
+    }
+
+    @SuppressWarnings({"LombokGetterMayBeUsed", "RedundantSuppression"})
+    public boolean isAerialVariant() {
+        return isAerialVariant;
+    }
+
+    @SuppressWarnings({"LombokGetterMayBeUsed", "RedundantSuppression"})
+    public boolean isFollowup() {
+        return isFollowup;
     }
 
     /**

--- a/common/src/main/java/net/arna/jcraft/common/util/JCodecUtils.java
+++ b/common/src/main/java/net/arna/jcraft/common/util/JCodecUtils.java
@@ -1,6 +1,7 @@
 package net.arna.jcraft.common.util;
 
 import com.google.common.base.Suppliers;
+import com.google.common.collect.BiMap;
 import com.google.common.collect.ImmutableMap;
 import com.google.gson.JsonParseException;
 import com.mojang.datafixers.Products;
@@ -261,6 +262,25 @@ public class JCodecUtils {
 
     public static <A> Codec<A> recursive(final String name, final Function<Codec<A>, Codec<A>> function) {
         return new RecursiveCodec<>(name, function);
+    }
+
+    public static <K, V> Codec<V> codecFromMap(final Codec<K> keyCodec, final BiMap<K, V> map) {
+        return keyCodec.flatXmap(
+            key -> {
+                if (map.containsKey(key)) {
+                    return DataResult.success(map.get(key));
+                } else {
+                    return DataResult.error(() -> "Unknown key: " + key);
+                }
+            },
+            value -> {
+                if (map.inverse().containsKey(value)) {
+                    return DataResult.success(map.inverse().get(value));
+                } else {
+                    return DataResult.error(() -> "Unknown value: " + value);
+                }
+            }
+        );
     }
 
     // From newer Minecraft version


### PR DESCRIPTION
Refactors the way actions are handled. Instead of actions and init_actions, we now only have actions. Instead, actions now have a 'run' property that defines when the action is ran. This allows for more customizability (actions can now be ran at init, on strike, on hit, at end, every tick or at a specific tick), while ensuring that current move files do not break (init_actions is now ignored while existing regular actions all run on strike).