### PR TITLE
CREAM CONFIG FINALLY!

### DIFF
--- a/common/src/main/java/net/arna/jcraft/common/config/JServerConfig.java
+++ b/common/src/main/java/net/arna/jcraft/common/config/JServerConfig.java
@@ -72,7 +72,7 @@ public class JServerConfig {
     public static final BooleanOption MINING_BARRAGE = new BooleanOption("miningBarrage", INTERACTION, true);
     public static final FloatOption METEOR_SPAWN_RATE = new FloatOption("meteorSpawnRate", INTERACTION, 0.02f, 0f, 1f);
     public static final IntOption DUMMY_DAMAGE_INDICATOR_RANGE = new IntOption("dummyDamageIndicatorRange", INTERACTION, 64, 0, 512);
-    public static final BooleanOption CREAM_ITEM_ERASE = new BooleanOption("creamItemErase", INTERACTION, false);
+    public static final BooleanOption CREAM_ITEM_ERASE = new BooleanOption("creamItemErase", INTERACTION, true);
     /*
     public static final BooleanOption UNIVERSAL_ABILITIES = new BooleanOption("universalAbilities", INTERACTION, true);
     public static final BooleanOption STAND_GRIEFING = new BooleanOption("standGriefing", INTERACTION, true);

--- a/common/src/main/java/net/arna/jcraft/common/config/JServerConfig.java
+++ b/common/src/main/java/net/arna/jcraft/common/config/JServerConfig.java
@@ -72,6 +72,7 @@ public class JServerConfig {
     public static final BooleanOption MINING_BARRAGE = new BooleanOption("miningBarrage", INTERACTION, true);
     public static final FloatOption METEOR_SPAWN_RATE = new FloatOption("meteorSpawnRate", INTERACTION, 0.02f, 0f, 1f);
     public static final IntOption DUMMY_DAMAGE_INDICATOR_RANGE = new IntOption("dummyDamageIndicatorRange", INTERACTION, 64, 0, 512);
+    public static final BooleanOption CREAM_ITEM_ERASE = new BooleanOption("creamItemErase", INTERACTION, false);
     /*
     public static final BooleanOption UNIVERSAL_ABILITIES = new BooleanOption("universalAbilities", INTERACTION, true);
     public static final BooleanOption STAND_GRIEFING = new BooleanOption("standGriefing", INTERACTION, true);

--- a/common/src/main/java/net/arna/jcraft/common/entity/stand/CreamEntity.java
+++ b/common/src/main/java/net/arna/jcraft/common/entity/stand/CreamEntity.java
@@ -21,6 +21,7 @@ import net.arna.jcraft.api.attack.StateContainer;
 import net.arna.jcraft.common.attack.moves.cream.*;
 import net.arna.jcraft.common.attack.moves.shared.*;
 import net.arna.jcraft.api.component.living.CommonHitPropertyComponent;
+import net.arna.jcraft.common.config.JServerConfig;
 import net.arna.jcraft.common.gravity.api.GravityChangerAPI;
 import net.arna.jcraft.common.util.JParticleType;
 import net.arna.jcraft.common.util.JUtils;
@@ -468,13 +469,19 @@ public class CreamEntity extends StandEntity<CreamEntity, CreamEntity.State> {
             if (server) {
                 if (level().getGameRules().getBoolean(JCraft.STAND_GRIEFING)) {
                     final BlockPos blockPos = blockPosition();
-                    // Unfun 3x4x3 void code
+                    // `Unfun` 3x4x3 void code
                     BlockPos from = blockPos.offset(-1, -1, -1);
                     BlockPos to = blockPos.offset(1, 2, 1);
                     BlockPos.betweenClosed(from, to).forEach(p -> {
                         if (level().getBlockState(p).getBlock().getExplosionResistance() > 100.1f) {
                             return;
                         }
+
+                        if (!JServerConfig.CREAM_ITEM_ERASE.getValue()) {
+                            // Drop items before destroying the block
+                            level().getBlockState(p).getBlock().dropResources(level().getBlockState(p), level(), p);
+                        }
+
                         level().setBlockAndUpdate(p, Block.stateById(0));
                     });
                 }
@@ -532,9 +539,11 @@ public class CreamEntity extends StandEntity<CreamEntity, CreamEntity.State> {
                 }
 
                 for (Entity ent : toDamage) {
-                    if (ent instanceof ItemEntity) {
-                        ent.discard();
-                        continue;
+                     if (ent instanceof ItemEntity) {
+                         if (JServerConfig.CREAM_ITEM_ERASE.getValue()) {
+                             ent.discard();
+                         }
+                         continue;
                     }
                     if (ent instanceof LivingEntity livingEntity) {
                         if (hurt) {

--- a/common/src/main/resources/assets/jcraft/lang/en_us.json
+++ b/common/src/main/resources/assets/jcraft/lang/en_us.json
@@ -732,6 +732,7 @@
   "jcraft.serverconfig.option.cmoonUltRange": "C-moon Ult Range",
   "jcraft.serverconfig.option.cmoonUtilDuration": "C-moon Util Duration",
   "jcraft.serverconfig.option.cooldownMultiplier": "Cooldown Duration Multiplier",
+  "jcraft.serverconfig.option.creamItemErase": "Cream Destroys Items",
   "jcraft.serverconfig.option.damageScalingMinimum": "Damage Scaling Minimum",
   "jcraft.serverconfig.option.defSpec": "Default Spec",
   "jcraft.serverconfig.option.disableCombatElytra": "Disable Elytra in Combat",


### PR DESCRIPTION
this config makes it so when its false - the blocks destroyed by cream drop their respective items, and when true, it erases items and the blocks destroyed dont drop their respective items. ayutac gave me the thumbs up for this. it only works when standgriefing is on. 